### PR TITLE
fix: use date adapter to display formatted date

### DIFF
--- a/projects/ngx-multiple-dates/src/lib/components/multiple-dates/multiple-dates.component.html
+++ b/projects/ngx-multiple-dates/src/lib/components/multiple-dates/multiple-dates.component.html
@@ -2,8 +2,8 @@
   <mat-chip *ngFor="let item of value; trackBy: trackByValue;"
             removable (removed)="removeChip(item)" [highlighted]="!!color"
             [color]="color" [ngClass]='getClassName(item)'>
-    {{ item | date : format }}
-    <mat-icon matChipRemove [attr.aria-label]="'remove ' + (item | date : format)">cancel</mat-icon>
+    {{ getDateFormat(item) }}
+    <mat-icon matChipRemove [attr.aria-label]="'remove ' + getDateFormat(item)">cancel</mat-icon>
   </mat-chip>
   <input *ngIf="isDatepicker; else simpleChipInput;" matInput hidden [value]="resetModel"
          [matDatepicker]="matDatepicker" [matDatepickerFilter]="matDatepickerFilter"

--- a/projects/ngx-multiple-dates/src/lib/components/multiple-dates/multiple-dates.component.ts
+++ b/projects/ngx-multiple-dates/src/lib/components/multiple-dates/multiple-dates.component.ts
@@ -625,4 +625,8 @@ export class MultipleDatesComponent<D = Date>
   private _getValidDateOrNull(obj: any): D | null {
     return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
   }
+
+  getDateFormat(date: any) {
+    return this._dateAdapter.format(date, this.format || undefined)
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation
- [ ] Other: <!-- Please describe -->


## What is the current behavior?
When using timezone with momentDateAdapter, because the datePipe refers to the client timezone, the date displayed in chips is wrong. Does not respect the timezone set in moment

Issue Number: 43


## What is the new behavior?
DateAdapter is used to show the formatted date in chips


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe. -->


## Other information
